### PR TITLE
DO NOT MERGE: expansion of dwalsh's comparison script

### DIFF
--- a/contrib/podman-commands.sh
+++ b/contrib/podman-commands.sh
@@ -1,15 +1,57 @@
-#!/bin/sh
-podman --help | sed -n -Ee '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman.cmd
-man podman | sed -n -e '0,/COMMANDS/d' -e '/^FILES/q;p' | grep podman | cut -f2 -d- | cut -f1 -d\( > /tmp/podman.man
-echo diff -B -u /tmp/podman.cmd /tmp/podman.man
-diff -B -u /tmp/podman.cmd /tmp/podman.man
+#!/bin/bash
 
-podman image --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-image.cmd
-man podman image | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-image.man
-echo diff -B -u /tmp/podman-image.cmd /tmp/podman-image.man
-diff -B -u /tmp/podman-image.cmd /tmp/podman-image.man
+# override with, e.g.,  PODMAN=./bin/podman
+PODMAN=${PODMAN:-podman}
 
-podman container --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-container.cmd
-man podman container | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-container.man
-echo diff -B -u /tmp/podman-container.cmd /tmp/podman-container.man
-diff -B -u /tmp/podman-container.cmd /tmp/podman-container.man
+function die() {
+    echo "FATAL: $*" >&2
+    exit 1
+}
+
+
+function podman_commands() {
+    $PODMAN help "$@" |\
+        awk '/^Available Commands:/{ok=1;next}/^Flags:/{ok=0}ok { print $1 }' |\
+        grep .
+}
+
+function podman_man() {
+    # - tr: remove nonalphanumeric and nonwhitespace characters
+    # - awk: print everything from COMMANDS or SUBCOMMANDS to next section
+    # - egrep: print the first or second column, matching podman-xxxxx
+    # - sed: strip away all except the last word, and remove the '(1)'
+    man ./docs/$1.1 |\
+        tr -cd 'a-zA-Z0-9 \012-' |\
+        awk '/^(SUB)?COMMANDS/{ok=1;next}/^[^ ]/{ok=0}ok' |\
+        egrep -o 'podman-[a-z0-9-]+' |\
+        sed -e 's/^.*-//' -e 's/1$//'
+}
+
+function compare_help_and_man() {
+    echo
+    echo "checking: $@"
+
+    # e.g. podman, podman-image, podman-volume
+    basename=$(echo podman "$@" | sed -e 's/ /-/g')
+
+    # uniq is necessary because, e.g., in podman-image.1 the 'list' and 'ls'
+    # commands reference 'podman-images(1)' (?!?)
+    podman_commands "$@" | sort | uniq > /tmp/${basename}_help.txt
+    podman_man $basename | sort | uniq > /tmp/${basename}_man.txt
+
+    diff -u /tmp/${basename}_help.txt /tmp/${basename}_man.txt
+
+    # Now look for subcommands, e.g. container, image
+    for cmd in $(< /tmp/${basename}_help.txt); do
+        # FIXME FIXME FIXME
+        usage=$($PODMAN "$@" $cmd --help | grep -A2 '^Usage:' | grep . | tail -1)
+
+        # if ends in '[command]', recurse into subcommands
+        if expr "$usage" : '.*\[command\]$' >/dev/null; then
+            compare_help_and_man "$@" $cmd
+        fi
+    done
+}
+
+
+compare_help_and_man

--- a/contrib/podman-commands.sh
+++ b/contrib/podman-commands.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+podman --help | sed -n -Ee '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman.cmd
+man podman | sed -n -e '0,/COMMANDS/d' -e '/^FILES/q;p' | grep podman | cut -f2 -d- | cut -f1 -d\( > /tmp/podman.man
+echo diff -B -u /tmp/podman.cmd /tmp/podman.man
+diff -B -u /tmp/podman.cmd /tmp/podman.man
+
+podman image --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-image.cmd
+man podman image | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-image.man
+echo diff -B -u /tmp/podman-image.cmd /tmp/podman-image.man
+diff -B -u /tmp/podman-image.cmd /tmp/podman-image.man
+
+podman container --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-container.cmd
+man podman container | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-container.man
+echo diff -B -u /tmp/podman-container.cmd /tmp/podman-container.man
+diff -B -u /tmp/podman-container.cmd /tmp/podman-container.man

--- a/docs/podman-container.1.md
+++ b/docs/podman-container.1.md
@@ -15,7 +15,7 @@ The container command allows you to manage containers
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
 | attach   | [podman-attach(1)](podman-attach.1.md)              | Attach to a running container.                                               |
 | checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoints one or more containers.                        |
-| cleanup  | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup containers network and mountpoints.                               |
+| cleanup  | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup containers network and mountpoints.                      |
 | commit   | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
 | create   | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |
 | diff     | [podman-diff(1)](podman-diff.1.md)                  | Inspect changes on a container or image's filesystem.                        |
@@ -24,19 +24,20 @@ The container command allows you to manage containers
 | export   | [podman-export(1)](podman-export.1.md)              | Export a container's filesystem contents as a tar archive.                   |
 | inspect  | [podman-inspect(1)](podman-inspect.1.md)            | Display a container or image's configuration.                                |
 | kill     | [podman-kill(1)](podman-kill.1.md)                  | Kill the main process in one or more containers.                             |
-| list     | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
+| list     | [podman-ps(1)](podman-ps.1.md)                      | List the containers on the system.                                           |
 | logs     | [podman-logs(1)](podman-logs.1.md)                  | Display the logs of a container.                                             |
-| ls       | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
+| ls       | [podman-ps(1)](podman-ps.1.md)                      | List the containers on the system.                                           |
 | mount    | [podman-mount(1)](podman-mount.1.md)                | Mount a working container's root filesystem.                                 |
 | pause    | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
 | port     | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
-| prune    | [podman-container-prune(1)](podman-container-prune.1.md)                  | Remove all stopped containers from local storage        |
-| ps       | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
+| prune    | [podman-container-prune(1)](podman-container-prune.1.md)                  | Remove all stopped containers from local storage       |
+| ps       | [podman-ps(1)](podman-ps.1.md)                      | List the containers on the system.                                           |
 | refresh  | [podman-refresh(1)](podman-container-refresh.1.md)  | Refresh the state of all containers                                          |
 | restart  | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |
 | restore  | [podman-container-restore(1)](podman-container-restore.1.md)  | Restores one or more containers from a checkpoint.                 |
 | rm       | [podman-rm(1)](podman-rm.1.md)                      | Remove one or more containers.                                               |
 | run      | [podman-run(1)](podman-run.1.md)                    | Run a command in a container.                                                |
+| runlabel | [podman-container-runlabel(1)](podman-container-runlabel.1.md)  | Executes a command as described by a container image label.      |
 | start    | [podman-start(1)](podman-start.1.md)                | Starts one or more containers.                                               |
 | stats    | [podman-stats(1)](podman-stats.1.md)                | Display a live stream of one or more container's resource usage statistics.  |
 | stop     | [podman-stop(1)](podman-stop.1.md)                  | Stop one or more running containers.                                         |

--- a/docs/podman-image.1.md
+++ b/docs/podman-image.1.md
@@ -14,21 +14,21 @@ The image command allows you to manage images
 | Command  | Man Page                                  | Description                                                                    |
 | -------- | ----------------------------------------- | ------------------------------------------------------------------------------ |
 | build    | [podman-build(1)](podman-build.1.md)      | Build a container using a Dockerfile.                                          |
-| exists   | [podman-exists(1)](podman-image-exists.1.md)      | Check if a image exists in local storage                                          |
+| exists   | [podman-exists(1)](podman-image-exists.1.md)      | Check if a image exists in local storage                               |
 | history  | [podman-history(1)](podman-history.1.md)  | Show the history of an image.                                                  |
 | import   | [podman-import(1)](podman-import.1.md)    | Import a tarball and save it as a filesystem image.                            |
 | inspect  | [podman-inspect(1)](podman-inspect.1.md)  | Display a image or image's configuration.                                      |
-| list     | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                           |
+| list     | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                       |
 | load     | [podman-load(1)](podman-load.1.md)        | Load an image from the docker archive.                                         |
-| ls       | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                           |
+| ls       | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                       |
+| prune    | [podman-image-prune(1)](podman-image-prune.1.md)        | Removed all unused images from the local store                   |
 | pull     | [podman-pull(1)](podman-pull.1.md)        | Pull an image from a registry.                                                 |
-| prune| [podman-container-prune(1)](podman-container-prune.1.md)        | Removed all unused images from the local store                                 |
 | push     | [podman-push(1)](podman-push.1.md)        | Push an image from local storage to elsewhere.                                 |
 | rm       | [podman-rm(1)](podman-rmi.1.md)           | Removes one or more locally stored images.                                     |
 | save     | [podman-save(1)](podman-save.1.md)        | Save an image to docker-archive or oci.                                        |
+| sign     | [podman-image-sign(1)](podman-image-sign.1.md)  | Sign an image.                                                           |
 | tag      | [podman-tag(1)](podman-tag.1.md)          | Add an additional name to a local image.                                       |
 | trust    | [podman-image-trust(1)](podman-image-trust.1.md)  | Manage container image trust policy.                                   |
-| sign    | [podman-image-sign(1)](podman-image-sign.1.md)  | Sign an image.                                                            |
 
 ## SEE ALSO
 podman

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -136,6 +136,8 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-diff(1)](podman-diff.1.md)        | Inspect changes on a container or image's filesystem.                          |
 | [podman-exec(1)](podman-exec.1.md)        | Execute a command in a running container.                                      |
 | [podman-export(1)](podman-export.1.md)    | Export a container's filesystem contents as a tar archive.                     |
+| [podman-generate(1)](podman-generate.1.md)| Generate structured data based for a containers and pods.                      |
+| [podman-help(1)](podman-history.1.md)     | Show help information on podman.                                               |
 | [podman-history(1)](podman-history.1.md)  | Show the history of an image.                                                  |
 | [podman-image(1)](podman-image.1.md)      | Manage Images.                                                                 |
 | [podman-images(1)](podman-images.1.md)    | List images in local storage.                                                  |
@@ -149,10 +151,13 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-logs(1)](podman-logs.1.md)        | Display the logs of a container.                                               |
 | [podman-mount(1)](podman-mount.1.md)      | Mount a working container's root filesystem.                                   |
 | [podman-pause(1)](podman-pause.1.md)      | Pause one or more containers.                                                  |
+| [podman-play(1)](podman-play.1.md)        | Play pods and containers based on a structured input file.                     |
+| [podman-pod(1)](podman-pod.1.md)          | Management tool for groups of containers, called pods.                         |
 | [podman-port(1)](podman-port.1.md)        | List port mappings for the container.                                          |
 | [podman-ps(1)](podman-ps.1.md)            | Prints out information about containers.                                       |
 | [podman-pull(1)](podman-pull.1.md)        | Pull an image from a registry.                                                 |
 | [podman-push(1)](podman-push.1.md)        | Push an image from local storage to elsewhere.                                 |
+| [podman-refresh(1)](podman-refresh.1.md)  | Refresh state of all containers to handle database changes.                    |
 | [podman-restart(1)](podman-restart.1.md)  | Restart one or more containers.                                                |
 | [podman-rm(1)](podman-rm.1.md)            | Remove one or more containers.                                                 |
 | [podman-rmi(1)](podman-rmi.1.md)          | Removes one or more locally stored images.                                     |
@@ -167,8 +172,9 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-top(1)](podman-top.1.md)          | Display the running processes of a container.                                  |
 | [podman-umount(1)](podman-umount.1.md)    | Unmount a working container's root filesystem.                                 |
 | [podman-unpause(1)](podman-unpause.1.md)  | Unpause one or more containers.                                                |
-| [podman-version(1)](podman-version.1.md)  | Display the Podman version information.                                        |
-| [podman-volume(1)](podman-volume.1.md)    | Manage Volumes.                                                                 |
+| [podman-varlink(1)](podman-varlink.1.md)  | Display the Podman version information.                                        |
+| [podman-version(1)](podman-version.1.md)  | Runs the varlink backend interface.                                            |
+| [podman-volume(1)](podman-volume.1.md)    | Manage Volumes.                                                                |
 | [podman-wait(1)](podman-wait.1.md)        | Wait on one or more containers to stop and print their exit codes.             |
 
 ## FILES


### PR DESCRIPTION
Something that compares _all_ subcommands. It's a horrible
mess because some man pages display COMMANDS and some
display SUBCOMMANDS; and some show the subcommand name
in the first column, others show the podman-xxx man page;
and there are inconsistencies galore.

This is a fake PR so Dan can look at the rest of the
inconsistencies that his script didn't look at

Signed-off-by: Ed Santiago <santiago@redhat.com>