### PR TITLE
Refactoring, and a usage tweak, for 2580

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -67,6 +67,19 @@ func noSubArgs(c *cobra.Command, args []string) error {
 	return nil
 }
 
+/// badSubArg complains about unrecognized commands or subcommands
+func badSubArg(c *cobra.Command, args []string) error {
+	var msg string
+
+	if len(args) > 0 {
+		msg = fmt.Sprintf("unrecognized command `%s %s`", c.CommandPath(), args[0])
+	} else {
+		msg = fmt.Sprintf("`%s` requires a subcommand", c.CommandPath())
+	}
+
+	return errors.Errorf(msg + "\nTry '%s --help' for more information", c.CommandPath())
+}
+
 // getAllOrLatestContainers tries to return the correct list of containers
 // depending if --all, --latest or <container-id> is used.
 // It requires the Context (c) and the Runtime (runtime). As different

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -537,7 +537,7 @@ Description:
 // This blocks the desplaying of the global options. The main podman
 // command should not use this.
 func UsageTemplate() string {
-	return `Usage:{{if .Runnable}}
+	return `Usage:{{if (and .Runnable (not .HasAvailableSubCommands))}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,9 @@ var (
 			Short:            "Manage Containers",
 			Long:             containerDescription,
 			TraverseChildren: true,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return errors.Errorf("unrecognized command `podman container %s`\nTry 'podman container --help' for more information.", args[0])
+			},
 		},
 	}
 

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -16,9 +15,7 @@ var (
 			Short:            "Manage Containers",
 			Long:             containerDescription,
 			TraverseChildren: true,
-			RunE: func(cmd *cobra.Command, args []string) error {
-				return errors.Errorf("unrecognized command `podman container %s`\nTry 'podman container --help' for more information.", args[0])
-			},
+			RunE:             badSubArg,
 		},
 	}
 

--- a/cmd/podman/generate.go
+++ b/cmd/podman/generate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,9 @@ var (
 		Use:   "generate",
 		Short: "Generated structured data",
 		Long:  generateDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.Errorf("unrecognized command `podman generate %s`\nTry 'podman generate --help' for more information.", args[0])
+		},
 	}
 )
 

--- a/cmd/podman/generate.go
+++ b/cmd/podman/generate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +12,7 @@ var (
 		Use:   "generate",
 		Short: "Generated structured data",
 		Long:  generateDescription,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.Errorf("unrecognized command `podman generate %s`\nTry 'podman generate --help' for more information.", args[0])
-		},
+		RunE:  badSubArg,
 	}
 )
 

--- a/cmd/podman/healthcheck.go
+++ b/cmd/podman/healthcheck.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -12,9 +11,7 @@ var healthcheckCommand = cliconfig.PodmanCommand{
 		Use:   "healthcheck",
 		Short: "Manage Healthcheck",
 		Long:  healthcheckDescription,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.Errorf("unrecognized command `podman healthcheck %s`\nTry 'podman healthcheck --help' for more information.", args[0])
-		},
+		RunE:  badSubArg,
 	},
 }
 

--- a/cmd/podman/healthcheck.go
+++ b/cmd/podman/healthcheck.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -11,6 +12,9 @@ var healthcheckCommand = cliconfig.PodmanCommand{
 		Use:   "healthcheck",
 		Short: "Manage Healthcheck",
 		Long:  healthcheckDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.Errorf("unrecognized command `podman healthcheck %s`\nTry 'podman healthcheck --help' for more information.", args[0])
+		},
 	},
 }
 

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,9 @@ var (
 			Use:   "image",
 			Short: "Manage images",
 			Long:  imageDescription,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return errors.Errorf("unrecognized command `podman image %s`\nTry 'podman image --help' for more information.", args[0])
+			},
 		},
 	}
 	imagesSubCommand  cliconfig.ImagesValues

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -15,9 +14,7 @@ var (
 			Use:   "image",
 			Short: "Manage images",
 			Long:  imageDescription,
-			RunE: func(cmd *cobra.Command, args []string) error {
-				return errors.Errorf("unrecognized command `podman image %s`\nTry 'podman image --help' for more information.", args[0])
-			},
+			RunE:  badSubArg,
 		},
 	}
 	imagesSubCommand  cliconfig.ImagesValues

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -82,9 +82,7 @@ var cmdsNotRequiringRootless = map[*cobra.Command]bool{
 var rootCmd = &cobra.Command{
 	Use:  "podman",
 	Long: "manage pods and images",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.Errorf("unrecognized command 'podman %s'\nTry 'podman --help' for more information.", args[0])
-	},
+	RunE: badSubArg,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return before(cmd, args)
 	},

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -83,7 +83,7 @@ var rootCmd = &cobra.Command{
 	Use:  "podman",
 	Long: "manage pods and images",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Help()
+		return errors.Errorf("unrecognized command 'podman %s'\nTry 'podman --help' for more information.", args[0])
 	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return before(cmd, args)

--- a/cmd/podman/play.go
+++ b/cmd/podman/play.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +12,7 @@ var (
 		Use:   "play",
 		Short: "Play a pod",
 		Long:  playDescription,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.Errorf("unrecognized command `podman play %s`\nTry 'podman play --help' for more information.", args[0])
-		},
+		RunE:  badSubArg,
 	}
 )
 

--- a/cmd/podman/play.go
+++ b/cmd/podman/play.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,9 @@ var (
 		Use:   "play",
 		Short: "Play a pod",
 		Long:  playDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.Errorf("unrecognized command `podman play %s`\nTry 'podman play --help' for more information.", args[0])
+		},
 	}
 )
 

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,9 +13,7 @@ var podCommand = cliconfig.PodmanCommand{
 		Use:   "pod",
 		Short: "Manage pods",
 		Long:  podDescription,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.Errorf("unrecognized command `podman pod %s`\nTry 'podman pod --help' for more information.", args[0])
-		},
+		RunE:  badSubArg,
 	},
 }
 

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,9 @@ var podCommand = cliconfig.PodmanCommand{
 		Use:   "pod",
 		Short: "Manage pods",
 		Long:  podDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.Errorf("unrecognized command `podman pod %s`\nTry 'podman pod --help' for more information.", args[0])
+		},
 	},
 }
 

--- a/cmd/podman/system.go
+++ b/cmd/podman/system.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,9 +13,7 @@ var (
 			Use:   "system",
 			Short: "Manage podman",
 			Long:  systemDescription,
-			RunE: func(cmd *cobra.Command, args []string) error {
-				return errors.Errorf("unrecognized command `podman system %s`\nTry 'podman system --help' for more information.", args[0])
-			},
+			RunE:  badSubArg,
 		},
 	}
 )

--- a/cmd/podman/system.go
+++ b/cmd/podman/system.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,9 @@ var (
 			Use:   "system",
 			Short: "Manage podman",
 			Long:  systemDescription,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return errors.Errorf("unrecognized command `podman system %s`\nTry 'podman system --help' for more information.", args[0])
+			},
 		},
 	}
 )

--- a/cmd/podman/trust.go
+++ b/cmd/podman/trust.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -15,9 +14,7 @@ var (
 			Use:   "trust",
 			Short: "Manage container image trust policy",
 			Long:  trustDescription,
-			RunE: func(cmd *cobra.Command, args []string) error {
-				return errors.Errorf("unrecognized command `podman image trust %s`\nTry 'podman image trust --help' for more information.", args[0])
-			},
+			RunE:  badSubArg,
 		},
 	}
 )

--- a/cmd/podman/trust.go
+++ b/cmd/podman/trust.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,9 @@ var (
 			Use:   "trust",
 			Short: "Manage container image trust policy",
 			Long:  trustDescription,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return errors.Errorf("unrecognized command `podman image trust %s`\nTry 'podman image trust --help' for more information.", args[0])
+			},
 		},
 	}
 )

--- a/cmd/podman/volume.go
+++ b/cmd/podman/volume.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +12,7 @@ var volumeCommand = cliconfig.PodmanCommand{
 		Use:   "volume",
 		Short: "Manage volumes",
 		Long:  volumeDescription,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.Errorf("unrecognized command `podman volume %s`\nTry 'podman volume --help' for more information.", args[0])
-		},
+		RunE:  badSubArg,
 	},
 }
 var volumeSubcommands = []*cobra.Command{

--- a/cmd/podman/volume.go
+++ b/cmd/podman/volume.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,9 @@ var volumeCommand = cliconfig.PodmanCommand{
 		Use:   "volume",
 		Short: "Manage volumes",
 		Long:  volumeDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.Errorf("unrecognized command `podman volume %s`\nTry 'podman volume --help' for more information.", args[0])
+		},
 	},
 }
 var volumeSubcommands = []*cobra.Command{


### PR DESCRIPTION
Add a `badSubArg` function to `common.go`, allowing for less duplication in each function that takes subcommands.

Tweak the Usage template to avoid multiple usage lines (one with [flags], one with [command]). Display just [command] when appropriate.


Signed-off-by: Ed Santiago <santiago@redhat.com>