### PR TITLE
Add ABISupport build tag to cross-compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ bin/podman.cross.%: .gopathok
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}" \
 	GOARCH="$${TARGET##*.}" \
-	$(GO_BUILD) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags '$(BUILDTAGS_CROSS)' -o "$@" $(PROJECT)/cmd/podman
+	$(GO_BUILD) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags 'ABISupport $(BUILDTAGS_CROSS)' -o "$@" $(PROJECT)/cmd/podman
 
 # Update nix/nixpkgs.json its latest master commit
 .PHONY: nixpkgs

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -123,7 +123,7 @@ func getNetworkResourceByName(name string, runtime *libpod.Runtime) (*types.Netw
 	report := types.NetworkResource{
 		Name:       name,
 		ID:         "",
-		Created:    time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec),
+		Created:    time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)),
 		Scope:      "",
 		Driver:     network.DefaultNetworkDriver,
 		EnableIPv6: false,


### PR DESCRIPTION
make local-cross is run in gating but it lacked the ABISupport build tag.  with it, we should catch such failures in the future and not rely on koji to catch them.

Signed-off-by: Brent Baude <bbaude@redhat.com>